### PR TITLE
(GH-5) Adds ability to start individual hosts within Vagrantfiles.

### DIFF
--- a/Vagrantey.psd1
+++ b/Vagrantey.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Vagrantey.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.4'
+ModuleVersion = '0.1.5'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/docs/Start-VagrantEnvironment.md
+++ b/docs/Start-VagrantEnvironment.md
@@ -12,8 +12,14 @@ Start a vagrant environment by specifying it's friendly name
 
 ## SYNTAX
 
+### Environment
 ```
-Start-VagrantEnvironment [-Environment] <String> [<CommonParameters>]
+Start-VagrantEnvironment [-Environment] <String> [-Name <String>] [<CommonParameters>]
+```
+
+### Id
+```
+Start-VagrantEnvironment -Id <String> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -33,11 +39,41 @@ The friendly name of the vagrant environment to start
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: Environment
 Aliases:
 
 Required: True
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Name of host in Vagrantfile to bring online, if multiple are defined in Vagrantfile.
+
+```yaml
+Type: String
+Parameter Sets: Environment
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Id
+Id of Vagrant environment to start, not tied to Environment parameter.
+
+```yaml
+Type: String
+Parameter Sets: Id
+Aliases:
+
+Required: True
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/public/Start-VagrantEnvironment.ps1
+++ b/public/Start-VagrantEnvironment.ps1
@@ -8,9 +8,27 @@ function Start-VagrantEnvironment {
     
     .PARAMETER Environment
     The friendly name of the vagrant environment to start
-    
+
+    .PARAMETER Name
+    Name of host in Vagrantfile to bring online, if multiple are defined in Vagrantfile.
+
+    .PARAMETER Id
+    Id of Vagrant environment to start, not tied to Environment parameter.
+
     .EXAMPLE
     Start-VagrantEnvironment -Environment CCM
+
+    Turn on all hosts defined in the CCM Vagrantfile
+
+    .EXAMPLE
+    Start-VagrantEnvironment -Environment CCM -Name client
+
+    Only turn on the client defined in the CCM Vagrantfile
+
+    .EXAMPLE
+    Start-VagrantEnvironment -Id a23459ef
+
+    Bring up specified vagrant ID
     
     .NOTES
     
@@ -18,7 +36,7 @@ function Start-VagrantEnvironment {
     
     [cmdletBinding()]
     Param(
-        [Parameter(Mandatory,Position=0)]
+        [Parameter(Mandatory,Position=0,ParameterSetName="Environment")]
         [ArgumentCompleter(
             {
                 param($Command,$Parameter,$WordToComplete,$CommandAst,$FakeBoundParams)
@@ -36,7 +54,33 @@ function Start-VagrantEnvironment {
             }
         )]
         [String]
-        $Environment
+        $Environment,
+
+        [Parameter(ParameterSetName="Environment")]
+        [String]
+        $Name,
+
+        [Parameter(Mandatory,ParameterSetName="Id")]
+        [ArgumentCompleter(
+            {
+                param($Command,$Parameter,$WordToComplete,$CommandAst,$FakeBoundParams)
+                $results = @((Get-VagrantEnvironment).Id)
+
+                If($WordToComplete){
+                    $results.Where{$_ -match "^$WordToComplete"}
+                }
+
+                Else {
+
+                    $results
+                }
+            }
+        )]
+        [String]
+        $Id
+
+
+
     )
 
     begin {
@@ -46,9 +90,34 @@ function Start-VagrantEnvironment {
 
     process {
 
-        Push-Location "$($config.$Environment)"
-        vagrant up
-        Pop-Location
+        Switch($PSCmdlet.ParameterSetName) {
+
+            "Environment" {
+
+                Push-Location "$($config.$Environment)"
+
+                if(!$Name) {
+                    vagrant up
+                }
+                
+                else {
+        
+                    vagrant up $Name
+        
+                }
+        
+                Pop-Location
+
+
+            }
+
+            "Id" {
+
+                vagrant up $Id
+
+            }
+
+        }
 
     }
 


### PR DESCRIPTION
Fixes #5 

* Adds `-Name` parameter to specify specific host within a Vagrant Environment to start.
* Adds `-Id` to start a specific Id from `Get-VagrantEnvironment`, regardless of Vagrant Environment