### PR TITLE
Fix regex to parse path properly

### DIFF
--- a/public/Get-VagrantEnvironment.ps1
+++ b/public/Get-VagrantEnvironment.ps1
@@ -26,7 +26,7 @@ function Get-VagrantEnvironment {
 
         Foreach($environment in $environments){
 
-            if($environment -match "^(?<id>[\w]+)\s+(?<name>[\w\-._]+)\s+(?<provider>[\w]+)\s+(?<state>[\w]+)\s+(?<path>[\/\-\w]+)"){
+            if($environment -match "^(?<id>[\w]+)\s+(?<name>[\w\-._]+)\s+(?<provider>[\w]+)\s+(?<state>[\w]+)\s+(?<path>[\/\-\w:]+)"){
            
                 [pscustomobject]@{
                     Id = $matches.id


### PR DESCRIPTION
Path from Get-VagrantEnvironment is not being parsed correctly. Instead of matching the path it is only match the drive letter. The addition of the `:` allows it to match the full path.